### PR TITLE
fix(angular-translate): update de version pour corriger xss

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,12 +13,12 @@
     "bootstrap": "~3.3.4",
     "angular-animate": "~1.3.15",
     "ng-tags-input": "2.3.0",
-    "angular-translate": "~2.6.1",
+    "angular-translate": "~2.17.0",
     "angular-language-picker": "k88hudson/angular-language-picker#~0.0.1",
     "iframe-resizer": "~2.8.5",
     "ng-table": "0.8.3",
     "angular-ui-notification": "~0.0.5",
-    "angular-translate-storage-cookie": "~2.6.1",
+    "angular-translate-storage-cookie": "~2.17.0",
     "angular-gravatar": "~0.3.1",
     "angular-relative-date": "~1.0.0",
     "angular-media-queries": "~0.4.0",
@@ -49,6 +49,7 @@
   "resolutions": {
     "angular": "1.3.15",
     "jquery": "2.1.4",
+    "angular-translate": "~2.17.0",
     "angular-bootstrap": "~0.13.0",
     "fullcalendar":"3.2.0"
   },


### PR DESCRIPTION
Salut,

Le correctif de Jean Louis semble bon, en tout cas pour la faille que nous avions trouvée.
Toutefois, il faut en plus forcer une version récente de **angular-translate** sinon la faille persiste.

C'est le contenu de cette PR

Matthieu