### PR TITLE
chore(gulp): proxyfication de /api pour le mode local

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,7 +63,7 @@ var middlewareDef = function() {
     }
 
     return [
-        configureProxy('/v0'),
+        configureProxy('/api'),
         configureProxy('/auth'),
         configureProxy('/_ah')
     ];


### PR DESCRIPTION
En lançant le front le proxy est exécuté pour `/v0 `au lieu de` /api`
Voici juste une modification du fichier gulp.

